### PR TITLE
Update Sassc version from 2.4.0 to 2.1.0 for deployment speed gains

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ source "https://rubygems.org"
 #
 # This will help ensure the proper Jekyll version is running.
 # Happy Jekylling!
+gem "sassc", "~> 2.1.0"
 gem "jekyll", "~> 4.2.0"
 # This is the default theme for new Jekyll sites. You may change this to anything you like.
 gem "minima", "~> 2.5"
@@ -27,4 +28,3 @@ end
 
 # Performance-booster for watching directories on Windows
 gem "wdm", "~> 0.1.1", :platforms => [:mingw, :x64_mingw, :mswin]
-

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,7 +59,7 @@ GEM
     rexml (3.2.4)
     rouge (3.26.0)
     safe_yaml (1.0.5)
-    sassc (2.4.0)
+    sassc (2.1.0)
       ffi (~> 1.9)
     terminal-table (2.0.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
@@ -72,6 +72,7 @@ DEPENDENCIES
   jekyll (~> 4.2.0)
   jekyll-feed (~> 0.12)
   minima (~> 2.5)
+  sassc (~> 2.1.0)
   tzinfo (~> 1.2)
   tzinfo-data
   wdm (~> 0.1.1)


### PR DESCRIPTION
Looks like 2.4.0 is taking a long time in Github actions; intarwebs says to move back to sassc 2.1.0 (compatible) which works locally.